### PR TITLE
Feature/aip 6326

### DIFF
--- a/src/schema/batch/batches.resolver.ts
+++ b/src/schema/batch/batches.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
+import { RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 
 import { PrismaService } from '../../prisma.service';
 import { Batch } from '../../authorization/models/batch.model';
@@ -14,6 +15,7 @@ export class BatchesResolver {
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	@Query((returns) => Batch, { name: 'batches' })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async GetBatchById(@Args('id') id: string): Promise<Batch> {
 		const batch = this.prismaService.batches.findUnique({
 			where: { id: id },

--- a/src/schema/decomposition/decomposition.resolver.ts
+++ b/src/schema/decomposition/decomposition.resolver.ts
@@ -1,6 +1,6 @@
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CommandBus } from '@nestjs/cqrs';
-import { Resource } from 'nest-keycloak-connect';
+import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 
 import { Element } from './models/element.model';
 import { ElementService } from './element.service';
@@ -20,6 +20,7 @@ export class DecompositionResolver {
 	) {}
 
 	@Mutation(() => Element)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createDecomposition(
 		@Args('assetCode') assetCode: string,
 		@Args('surveyId') surveyId: string,
@@ -34,6 +35,7 @@ export class DecompositionResolver {
 	}
 
 	@Query((returns) => [Element], { name: 'elements' })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	async findSurveyElements(@Args('surveyId', { type: () => String }) surveyId: string): Promise<Element[]> {
 		return this.commandBus.execute<FindSurveyElementsCommand>(new FindSurveyElementsCommand(surveyId));
 	}

--- a/src/schema/decomposition/element.resolver.ts
+++ b/src/schema/decomposition/element.resolver.ts
@@ -1,11 +1,11 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { Resource, Roles } from 'nest-keycloak-connect';
-import { UseGuards } from '@nestjs/common';
+import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
+// import { UseGuards } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 
-import { PoliciesGuard } from '../../authorization/policies.guard';
-import { WriteAssetPolicyHandler } from '../../authorization/policies/write-asset.policy-handler';
-import { CheckPolicies } from '../../authorization/check-policies.decorator';
+// import { PoliciesGuard } from '../../authorization/policies.guard';
+// import { WriteAssetPolicyHandler } from '../../authorization/policies/write-asset.policy-handler';
+// import { CheckPolicies } from '../../authorization/check-policies.decorator';
 
 import { Element } from './models/element.model';
 import { ElementFactory } from './element.factory';
@@ -23,6 +23,7 @@ export class ElementResolver {
 	constructor(private elementService: ElementService, private commandBus: CommandBus) {}
 
 	@Mutation(() => Element)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createElement(@Args('createElement') input: CreateElementInput): Promise<Element> {
 		const domainElement: DomainElement = await this.commandBus.execute<CreateElementCommand>(
 			new CreateElementCommand(input),
@@ -31,6 +32,7 @@ export class ElementResolver {
 	}
 
 	@Mutation(() => Element)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateElement(@Args('updateElement') input: UpdateElementInput): Promise<Element> {
 		const domainElement: DomainElement = await this.commandBus.execute<UpdateElementCommand>(
 			new UpdateElementCommand(input),
@@ -39,6 +41,7 @@ export class ElementResolver {
 	}
 
 	@Mutation(() => Element)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteElement(@Args('identifier') identifier: string): Promise<Element> {
 		const domainElement: DomainElement = await this.commandBus.execute<DeleteElementCommand>(
 			new DeleteElementCommand(identifier),
@@ -47,22 +50,23 @@ export class ElementResolver {
 	}
 
 	@Query((returns) => [Element], { name: 'decompositionElements' })
-	@Roles({ roles: ['realm:aip_owner'] })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	async getSurveyElements(@Args('surveyId', { type: () => String }) surveyId: string) {
 		return this.elementService.getElements(surveyId);
 	}
 
-	@Query((returns) => [Element], { name: 'tester' })
-	@UseGuards(PoliciesGuard)
-	@CheckPolicies(new WriteAssetPolicyHandler())
-	async tester(@Args('code', { type: () => String }) code: string) {
-		return [];
-	}
-
-	@Query((returns) => [Element], { name: 'tester2' })
-	@UseGuards(PoliciesGuard)
-	@CheckPolicies(new WriteAssetPolicyHandler())
-	async tester2(@Args('code', { type: () => String }) code: string) {
-		return [];
-	}
+	// Leaving this here on purpose to illustrate usage of the PoliciesGuard
+	// @Query((returns) => [Element], { name: 'tester' })
+	// @UseGuards(PoliciesGuard)
+	// @CheckPolicies(new WriteAssetPolicyHandler())
+	// async tester(@Args('code', { type: () => String }) code: string) {
+	// 	return [];
+	// }
+	//
+	// @Query((returns) => [Element], { name: 'tester2' })
+	// @UseGuards(PoliciesGuard)
+	// @CheckPolicies(new WriteAssetPolicyHandler())
+	// async tester2(@Args('code', { type: () => String }) code: string) {
+	// 	return [];
+	// }
 }

--- a/src/schema/decomposition/manifestation.resolver.ts
+++ b/src/schema/decomposition/manifestation.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { CommandBus } from '@nestjs/cqrs';
+import { RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 
 import { Manifestation as DomainManifestation } from './types/manifestation.repository.interface';
 import { ManifestationService } from './manifestation.service';
@@ -16,6 +17,7 @@ export class ManifestationResolver {
 	constructor(private manifestationService: ManifestationService, private commandBus: CommandBus) {}
 
 	@Mutation(() => Manifestation)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createManifestation(
 		@Args('createManifestation') input: CreateManifestationInput,
 	): Promise<Manifestation> {
@@ -27,6 +29,7 @@ export class ManifestationResolver {
 	}
 
 	@Mutation(() => Manifestation)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateManifestation(
 		@Args('updateManifestation') input: UpdateManifestationInput,
 	): Promise<Manifestation> {
@@ -38,6 +41,7 @@ export class ManifestationResolver {
 	}
 
 	@Mutation(() => Manifestation)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteManifestation(@Args('identifier') identifier: string): Promise<Manifestation> {
 		const domainManifestation: DomainManifestation = await this.commandBus.execute<DeleteManifestationCommand>(
 			new DeleteManifestationCommand(identifier),

--- a/src/schema/decomposition/unit.resolver.ts
+++ b/src/schema/decomposition/unit.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { CommandBus } from '@nestjs/cqrs';
+import { RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 
 import { Unit as DomainUnit } from './types/unit.repository.interface';
 import { UnitService } from './unit.service';
@@ -18,12 +19,14 @@ export class UnitResolver {
 	constructor(private unitService: UnitService, private commandBus: CommandBus) {}
 
 	@Mutation(() => Unit)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createUnit(@Args('createUnit') input: CreateUnitInput): Promise<Unit> {
 		const domainUnit: DomainUnit = await this.commandBus.execute<CreateUnitCommand>(new CreateUnitCommand(input));
 		return UnitFactory.CreateUnit(domainUnit);
 	}
 
 	@Mutation(() => Unit)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateUnit(@Args('updateUnit') input: UpdateUnitInput): Promise<Unit> {
 		const domainUnit: DomainUnit = await this.commandBus.execute<UpdateUnitCommand>(new UpdateUnitCommand(input));
 
@@ -31,6 +34,7 @@ export class UnitResolver {
 	}
 
 	@Mutation(() => Unit)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteUnit(@Args('identifier') identifier: string): Promise<Unit> {
 		const domainUnit: DomainUnit = await this.commandBus.execute<DeleteUnitCommand>(
 			new DeleteUnitCommand(identifier),

--- a/src/schema/span-installation/junction-box-resolver.ts
+++ b/src/schema/span-installation/junction-box-resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { Resource, Roles } from 'nest-keycloak-connect';
+import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 import { CommandBus } from '@nestjs/cqrs';
 
 import { JunctionBox } from './models/junction-box.model';
@@ -18,6 +18,7 @@ export class JunctionBoxResolver {
 	constructor(private junctionBoxService: JunctionBoxService, private commandBus: CommandBus) {}
 
 	@Mutation(() => JunctionBox)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createJunctionBox(@Args('createJunctionBox') input: CreateJunctionBoxInput): Promise<JunctionBox> {
 		const domainJunctionBox: DomainJunctionBox = await this.commandBus.execute<CreateJunctionBoxCommand>(
 			new CreateJunctionBoxCommand(input),
@@ -26,6 +27,7 @@ export class JunctionBoxResolver {
 	}
 
 	@Mutation(() => JunctionBox)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateJunctionBox(@Args('updateJunctionBox') input: UpdateJunctionBoxInput): Promise<JunctionBox> {
 		const domainJunctionBox: DomainJunctionBox = await this.commandBus.execute<UpdateJunctionBoxCommand>(
 			new UpdateJunctionBoxCommand(input),
@@ -34,6 +36,7 @@ export class JunctionBoxResolver {
 	}
 
 	@Mutation(() => JunctionBox)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteJunctionBox(@Args('identifier') identifier: string): Promise<JunctionBox> {
 		const domainJunctionBox: DomainJunctionBox = await this.commandBus.execute<DeleteJunctionBoxCommand>(
 			new DeleteJunctionBoxCommand(identifier),
@@ -42,7 +45,7 @@ export class JunctionBoxResolver {
 	}
 
 	@Query((returns) => [JunctionBox], { name: 'spanInstallationJunctionBoxes' })
-	@Roles({ roles: ['realm:aip_owner'] })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
 	async getSurveyJunctionBoxes(@Args('surveyId', { type: () => String }) surveyId: string) {
 		return this.junctionBoxService.getJunctionBoxes(surveyId);
 	}

--- a/src/schema/span-installation/luminaire.resolver.ts
+++ b/src/schema/span-installation/luminaire.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { Resource, Roles } from 'nest-keycloak-connect';
+import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 import { CommandBus } from '@nestjs/cqrs';
 
 import { Luminaire } from './models/luminaire.model';
@@ -18,6 +18,7 @@ export class LuminaireResolver {
 	constructor(private luminaireService: LuminaireService, private commandBus: CommandBus) {}
 
 	@Mutation(() => Luminaire)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createLuminaire(@Args('createLuminaire') input: CreateLuminaireInput): Promise<Luminaire> {
 		const domainLuminaire: DomainLuminaire = await this.commandBus.execute<CreateLuminaireCommand>(
 			new CreateLuminaireCommand(input),
@@ -26,6 +27,7 @@ export class LuminaireResolver {
 	}
 
 	@Mutation(() => Luminaire)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateLuminaire(@Args('updateLuminaire') input: UpdateLuminaireInput): Promise<Luminaire> {
 		const domainLuminaire: DomainLuminaire = await this.commandBus.execute<UpdateLuminaireCommand>(
 			new UpdateLuminaireCommand(input),
@@ -34,6 +36,7 @@ export class LuminaireResolver {
 	}
 
 	@Mutation(() => Luminaire)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteLuminaire(@Args('identifier') identifier: string): Promise<Luminaire> {
 		const domainLuminaire: DomainLuminaire = await this.commandBus.execute<DeleteLuminaireCommand>(
 			new DeleteLuminaireCommand(identifier),
@@ -42,7 +45,7 @@ export class LuminaireResolver {
 	}
 
 	@Query((returns) => [Luminaire], { name: 'spanInstallationLuminaires' })
-	@Roles({ roles: ['realm:aip_owner'] })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
 	async getsupportSystemLuminaires(@Args('supportSystemId', { type: () => String }) supportSystemId: string) {
 		return this.luminaireService.getLuminaires(supportSystemId);
 	}

--- a/src/schema/span-installation/support-system.resolver.ts
+++ b/src/schema/span-installation/support-system.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { Resource, Roles } from 'nest-keycloak-connect';
+import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 
 import { SupportSystem } from './models/support-system.model';
@@ -25,6 +25,7 @@ export class SupportSystemResolver {
 	) {}
 
 	@Mutation(() => SupportSystem)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async createSupportSystem(
 		@Args('createSupportSystem') input: CreateSupportSystemInput,
 	): Promise<SupportSystem> {
@@ -35,6 +36,7 @@ export class SupportSystemResolver {
 	}
 
 	@Mutation(() => SupportSystem)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async updateSupportSystem(
 		@Args('updateSupportSystem') input: UpdateSupportSystemInput,
 	): Promise<SupportSystem> {
@@ -45,6 +47,7 @@ export class SupportSystemResolver {
 	}
 
 	@Mutation(() => SupportSystem)
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin'], mode: RoleMatchingMode.ANY })
 	public async deleteSupportSystem(@Args('identifier') identifier: string): Promise<SupportSystem> {
 		const domainSupportSystem: DomainSupportSystem = await this.commandBus.execute<DeleteSupportSystemCommand>(
 			new DeleteSupportSystemCommand(identifier),
@@ -53,7 +56,7 @@ export class SupportSystemResolver {
 	}
 
 	@Query((returns) => [SupportSystem], { name: 'spanInstallationSupportSystems' })
-	@Roles({ roles: ['realm:aip_owner'] })
+	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
 	async getSurveySupportSystems(@Args('surveyId', { type: () => String }) surveyId: string) {
 		return this.queryBus.execute<FindSupportSystemsQuery>(new FindSupportSystemsQuery(surveyId));
 	}


### PR DESCRIPTION
For now I've added keycloak role based authorization on all GraphQL mutations/queries.
The keycloak token needs to contain the admin or owner role to be granted access.
Users with the surveyor role can however fetch spanInstallation decomposition.