### PR TITLE
chore(dependabot): dependabot to target the acceptance branch instead…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
+    - package-ecosystem: 'npm' # See documentation for possible values
+      directory: '/' # Location of package manifests
+      schedule:
+          interval: 'daily'
+      target-branch: 'acceptance'


### PR DESCRIPTION
… of main

It seems a bit reckless to merge dependabot MRs straight into main. By targeting acceptance instead we are able to deploy updates to our acceptance environment first for verification.