### PR TITLE
refactor: getArkSurveyData now returns a single object instead of an array of objects

### DIFF
--- a/src/schema/ark-survey/__mocks__/ark-survey.repository.ts
+++ b/src/schema/ark-survey/__mocks__/ark-survey.repository.ts
@@ -3,5 +3,5 @@ import { domainArkSurvey, ArkSurvey } from '../__stubs__';
 export const ArkSurveyRepository = jest.fn(() => ({
 	createArkSurvey: jest.fn(() => ArkSurvey),
 	updateArkSurvey: jest.fn(() => ArkSurvey),
-	getArkSurveyData: jest.fn(() => [domainArkSurvey]),
+	getArkSurveyData: jest.fn(() => domainArkSurvey),
 }));

--- a/src/schema/ark-survey/__mocks__/ark-survey.service.ts
+++ b/src/schema/ark-survey/__mocks__/ark-survey.service.ts
@@ -1,5 +1,5 @@
 import { ArkSurvey } from '../__stubs__';
 
 export const ArkSurveyService = jest.fn(() => ({
-	getArkSurveyData: jest.fn(() => [ArkSurvey, ArkSurvey]),
+	getArkSurveyData: jest.fn(() => ArkSurvey),
 }));

--- a/src/schema/ark-survey/ark-survey.repository.ts
+++ b/src/schema/ark-survey/ark-survey.repository.ts
@@ -60,21 +60,19 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 		};
 	}
 
-	async getArkSurveyData(surveyId: string): Promise<ArkSurvey[]> {
-		const geographyDataResult = (await this.prisma.arkSurveys.findMany({
-			where: {
-				surveyId,
-				deleted_at: null,
-			},
-		})) as ArkSurvey[];
+	async getArkSurveyData(surveyId: string): Promise<ArkSurvey> {
+		const survey = (await this.prisma.arkSurveys.findFirst({
+			where: { surveyId: surveyId },
+		})) as ArkSurvey;
 
-		return Promise.all(
-			geographyDataResult.map(async (result) => {
-				result.arkGeographyStart = await this.getGeographyAsGeoJSONStart(result.surveyId);
-				result.arkGeographyEnd = await this.getGeographyAsGeoJSONEnd(result.surveyId);
-				return result;
-			}),
-		);
+		survey.arkGeographyStart = await this.getGeographyAsGeoJSONStart(survey.surveyId);
+		survey.arkGeographyEnd = await this.getGeographyAsGeoJSONEnd(survey.surveyId);
+
+		if (!survey) {
+			throw new Error('No ARK survey found.');
+		}
+
+		return survey;
 	}
 
 	async updateArkSurvey({

--- a/src/schema/ark-survey/ark-survey.resolver.spec.ts
+++ b/src/schema/ark-survey/ark-survey.resolver.spec.ts
@@ -95,11 +95,11 @@ describe('ARK / ArkSurvey / Resolver', () => {
 		});
 	});
 
-	test('getArkSurvey returns an array of ArkSurvey objects', async () => {
+	test('getArkSurvey returns an ArkSurvey object', async () => {
 		const commandBusMock = getCommandBusMock();
 		const queryBusMock = getQueryBusMock();
 		const resolver = new ArkSurveyResolver(new ArkSurveyService(ArkSurveyRepo), commandBusMock, queryBusMock);
 		const elements = await resolver.getArkSurvey('ad18b7c4-b2ef-4e6e-9bbf-c33360584cd7');
-		expect(elements).toEqual([domainArkSurvey, domainArkSurvey]);
+		expect(elements).toEqual(domainArkSurvey);
 	});
 });

--- a/src/schema/ark-survey/ark-survey.resolver.ts
+++ b/src/schema/ark-survey/ark-survey.resolver.ts
@@ -17,6 +17,7 @@ import { DeleteArkSurveyCommand } from './commands/delete-ark-survey.command';
 import { FindArkSurveyQuery } from './queries/find-ark-survey.query';
 import { SaveArkSurveyCommand } from './commands/save-ark-survey.command';
 import { FindArkSurveyReachSegmentsCommand } from './commands/find-ark-survey-reach-segments.command';
+import { GetArkSurveyBySurveyIdQuery } from './queries/get-ark-survey-by-survey-id.query';
 
 @Resolver((of) => ArkSurvey)
 @Resource(ArkSurvey.name)
@@ -63,11 +64,17 @@ export class ArkSurveyResolver {
 		return ArkSurveyFactory.createArkSurvey(domainArkSurvey);
 	}
 
-	@Query((returns) => [ArkSurvey], { name: 'getArkSurvey' })
+	@Query((returns) => ArkSurvey, { name: 'getArkSurvey' })
 	@Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
 	async getArkSurvey(@Args('surveyId', { type: () => String }) surveyId: string) {
 		return this.arkSurveyService.getArkSurveyData(surveyId);
 	}
+
+	// @Query(() => ArkSurvey)
+	// @Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
+	// public async getArkSurvey(@Args('surveyId') surveyId: string): Promise<ArkSurvey> {
+	// 	return this.queryBus.execute<GetArkSurveyBySurveyIdQuery>(new GetArkSurveyBySurveyIdQuery(surveyId));
+	// }
 
 	@ResolveField()
 	async reachSegments(@Parent() { id }: ArkSurvey): Promise<ReachSegment[]> {

--- a/src/schema/ark-survey/ark-survey.resolver.ts
+++ b/src/schema/ark-survey/ark-survey.resolver.ts
@@ -70,12 +70,6 @@ export class ArkSurveyResolver {
 		return this.arkSurveyService.getArkSurveyData(surveyId);
 	}
 
-	// @Query(() => ArkSurvey)
-	// @Roles({ roles: ['realm:aip_owner', 'realm:aip_admin', 'realm:aip_survey'], mode: RoleMatchingMode.ANY })
-	// public async getArkSurvey(@Args('surveyId') surveyId: string): Promise<ArkSurvey> {
-	// 	return this.queryBus.execute<GetArkSurveyBySurveyIdQuery>(new GetArkSurveyBySurveyIdQuery(surveyId));
-	// }
-
 	@ResolveField()
 	async reachSegments(@Parent() { id }: ArkSurvey): Promise<ReachSegment[]> {
 		return this.commandBus.execute<FindArkSurveyReachSegmentsCommand>(new FindArkSurveyReachSegmentsCommand(id));

--- a/src/schema/ark-survey/ark-survey.service.spec.ts
+++ b/src/schema/ark-survey/ark-survey.service.spec.ts
@@ -17,13 +17,10 @@ const prismaServiceMock: MockedObjectDeep<PrismaService> = {
 const repo = new ArkSurveyRepository(prismaServiceMock);
 
 describe('ARK Reach Segments / Service', () => {
-	test('getArkSurveyData returns an array of ArkSurvey objects', async () => {
+	test('getArkSurveyData returns an ArkSurvey object', async () => {
 		const service = new ArkSurveyService(repo);
 		const ArkSurveyResults = await service.getArkSurveyData('ad18b7c4-b2ef-4e6e-9bbf-c33360584cd7');
-		expect(ArkSurveyResults).toBeInstanceOf(Array);
-		expect(ArkSurveyResults[0]).toBeInstanceOf(ArkSurvey);
-		expect(ArkSurveyResults).toEqual(
-			[domainArkSurvey].map((arkSurvey) => ArkSurveyFactory.createArkSurvey(arkSurvey)),
-		);
+		expect(ArkSurveyResults).toBeInstanceOf(ArkSurvey);
+		expect(ArkSurveyResults).toEqual(ArkSurveyFactory.createArkSurvey(domainArkSurvey));
 	});
 });

--- a/src/schema/ark-survey/ark-survey.service.ts
+++ b/src/schema/ark-survey/ark-survey.service.ts
@@ -8,9 +8,7 @@ import { ArkSurvey } from './models/ark-survey.model';
 export class ArkSurveyService {
 	public constructor(private readonly arkSurveyRepository: ArkSurveyRepository) {}
 
-	async getArkSurveyData(surveyId: string): Promise<ArkSurvey[]> {
-		return (await this.arkSurveyRepository.getArkSurveyData(surveyId)).map((geographyData) =>
-			ArkSurveyFactory.createArkSurvey(geographyData),
-		);
+	async getArkSurveyData(surveyId: string): Promise<ArkSurvey> {
+		return ArkSurveyFactory.createArkSurvey(await this.arkSurveyRepository.getArkSurveyData(surveyId));
 	}
 }

--- a/src/schema/ark-survey/queries/find-ark-survey.handler.ts
+++ b/src/schema/ark-survey/queries/find-ark-survey.handler.ts
@@ -9,7 +9,7 @@ import { FindArkSurveyQuery } from './find-ark-survey.query';
 export class FindArkSurveyHandler implements IQueryHandler<FindArkSurveyQuery> {
 	constructor(private service: ArkSurveyService) {}
 
-	async execute(query: FindArkSurveyQuery): Promise<ArkSurvey[]> {
+	async execute(query: FindArkSurveyQuery): Promise<ArkSurvey> {
 		return this.service.getArkSurveyData(query.surveyId);
 	}
 }

--- a/src/schema/ark-survey/types/ark-survey.repository.interface.ts
+++ b/src/schema/ark-survey/types/ark-survey.repository.interface.ts
@@ -23,7 +23,7 @@ export type ArkSurvey = ArkSurveyWithoutGeography & {
 };
 
 export interface IArkSurveyRepository {
-	getArkSurveyData(surveyId: string): Promise<ArkSurvey[]>;
+	getArkSurveyData(surveyId: string): Promise<ArkSurvey>;
 	createArkSurvey(input: CreateArkSurveyInput): Promise<ArkSurvey>;
 	updateArkSurvey(input: UpdateArkSurveyInput): Promise<ArkSurvey>;
 	deleteArkSurvey(identifier: string): Promise<ArkSurvey>;


### PR DESCRIPTION
It was pointed out to me that even though we only expect a single `arkSurvey` record to exist, the `getArkSurveyData` query returned an array instead of a a single object. This PR changes this. 