### PR TITLE
refactor: move findPreviousSurveyId method from decomposition.repository to survey.repository

### DIFF
--- a/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.handler.ts
+++ b/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.handler.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { SurveyRepository } from 'src/schema/survey/survey.repository';
 
 import { DecompositionRepository } from '../decomposition.repository';
 import { Element } from '../models/element.model';
@@ -10,10 +11,10 @@ import { CloneDecompositionFromPreviousSurveyCommand } from './clone-decompositi
 export class CloneDecompositionFromPreviousSurveyHandler
 	implements ICommandHandler<CloneDecompositionFromPreviousSurveyCommand>
 {
-	constructor(private decompositionRepository: DecompositionRepository) {}
+	constructor(private decompositionRepository: DecompositionRepository, private surveyRepository: SurveyRepository) {}
 
 	public async execute(command: CloneDecompositionFromPreviousSurveyCommand): Promise<Element[]> {
-		const previousSurveyId = await this.decompositionRepository.findPreviousSurveyId(command.surveyId);
+		const previousSurveyId = await this.surveyRepository.findPreviousSurveyId(command.surveyId);
 
 		if (await this.decompositionRepository.checkIfAlreadyMigrated(command.surveyId)) {
 			throw new SurveyHasDecompositionException(command.surveyId);

--- a/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.handler.ts
+++ b/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.handler.ts
@@ -14,7 +14,9 @@ export class CloneDecompositionFromPreviousSurveyHandler
 	constructor(private decompositionRepository: DecompositionRepository, private surveyRepository: SurveyRepository) {}
 
 	public async execute(command: CloneDecompositionFromPreviousSurveyCommand): Promise<Element[]> {
-		const previousSurveyId = await this.surveyRepository.findPreviousSurveyId(command.surveyId);
+		const previousSurveyId = await this.surveyRepository.findIdPreviousSurveyWithNen2767Decomposition(
+			command.surveyId,
+		);
 
 		if (await this.decompositionRepository.checkIfAlreadyMigrated(command.surveyId)) {
 			throw new SurveyHasDecompositionException(command.surveyId);

--- a/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.spec.ts
+++ b/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.spec.ts
@@ -1,3 +1,4 @@
+import { SurveyRepository } from 'src/schema/survey/survey.repository';
 import { MockedObjectDeep } from 'ts-jest';
 
 import { DecompositionRepository } from '../decomposition.repository';
@@ -7,16 +8,20 @@ import { CloneDecompositionFromPreviousSurveyCommand } from './clone-decompositi
 import { CloneDecompositionFromPreviousSurveyHandler } from './clone-decomposition-from-previous-survey.handler';
 
 const decompositionRepoMock: MockedObjectDeep<DecompositionRepository> = {
-	findPreviousSurveyId: jest.fn().mockResolvedValue('__PREVIOUS_SURVEY_ID__'),
 	checkIfAlreadyMigrated: jest.fn().mockResolvedValue(false),
 	cloneDecomposition: jest.fn().mockResolvedValue([domainElement, domainElement]),
+	...(<any>{}),
+};
+
+const surveyRepoMock: MockedObjectDeep<SurveyRepository> = {
+	findPreviousSurveyId: jest.fn().mockResolvedValue('__PREVIOUS_SURVEY_ID__'),
 	...(<any>{}),
 };
 
 describe('CloneDecompositionFromPreviousSurveyCommand', () => {
 	test('executes command', async () => {
 		const command = new CloneDecompositionFromPreviousSurveyCommand('__SURVEY_ID__');
-		await new CloneDecompositionFromPreviousSurveyHandler(decompositionRepoMock).execute(command);
+		await new CloneDecompositionFromPreviousSurveyHandler(decompositionRepoMock, surveyRepoMock).execute(command);
 
 		expect(decompositionRepoMock.cloneDecomposition).toHaveBeenCalledTimes(1);
 	});

--- a/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.spec.ts
+++ b/src/schema/decomposition/commands/clone-decomposition-from-previous-survey.spec.ts
@@ -14,7 +14,7 @@ const decompositionRepoMock: MockedObjectDeep<DecompositionRepository> = {
 };
 
 const surveyRepoMock: MockedObjectDeep<SurveyRepository> = {
-	findPreviousSurveyId: jest.fn().mockResolvedValue('__PREVIOUS_SURVEY_ID__'),
+	findIdPreviousSurveyWithNen2767Decomposition: jest.fn().mockResolvedValue('__PREVIOUS_SURVEY_ID__'),
 	...(<any>{}),
 };
 

--- a/src/schema/decomposition/decomposition.repository.spec.ts
+++ b/src/schema/decomposition/decomposition.repository.spec.ts
@@ -1,7 +1,6 @@
 import { PrismaService } from 'src/prisma.service';
 import { MockedObjectDeep } from 'ts-jest';
 
-import { Survey } from '../survey/models/survey.model';
 import { domainSurvey } from '../survey/__stubs__';
 
 import { DecompositionRepository } from './decomposition.repository';
@@ -45,19 +44,6 @@ const elementsServiceMock: MockedObjectDeep<ElementService> = {
 const repo = new DecompositionRepository(elementsServiceMock, prismaServiceMock);
 
 describe('Decomposition / Repository', () => {
-	describe('findPrevousSurveyId()', () => {
-		test('returns the id of the survey with the same objectId created prior to the given surveyId, based on the created_at field', async () => {
-			prismaServiceMock.surveys.findFirst.mockResolvedValue({
-				...domainSurvey,
-				id: '__PREVIOUS_SURVEY_ID__',
-			} as Survey);
-
-			const resultId = await repo.findPreviousSurveyId('__SURVEY_ID__');
-
-			expect(resultId).toEqual('__PREVIOUS_SURVEY_ID__');
-		});
-	});
-
 	describe('cloneDecomposition()', () => {
 		test('clones a decomposition from the previous survey and returns the decomposition structure', async () => {
 			await repo.cloneDecomposition('__SURVEY_ID___', '___PREVIOUS_SUREY_ID___');

--- a/src/schema/decomposition/decomposition.repository.ts
+++ b/src/schema/decomposition/decomposition.repository.ts
@@ -3,7 +3,6 @@ import PQueue from 'p-queue';
 import { PrismaService } from 'src/prisma.service';
 
 import { newId } from '../../utils/newId';
-import { SurveyStates } from '../survey/types/surveyStates';
 
 import { ElementService } from './element.service';
 import { Element } from './models/element.model';
@@ -99,36 +98,6 @@ export class DecompositionRepository {
 		await queue.onIdle();
 
 		return this.elementService.getElements(surveyId);
-	}
-
-	public async findPreviousSurveyId(surveyId: string): Promise<string | null> {
-		const current = await this.prisma.surveys.findFirst({
-			where: {
-				id: surveyId,
-			},
-
-			select: {
-				id: true,
-				objectId: true,
-				inspectionStandardType: true,
-			},
-		});
-
-		const previous = await this.prisma.surveys.findFirst({
-			where: {
-				objectId: current.objectId,
-				inspectionStandardType: current.inspectionStandardType,
-				NOT: [{ id: current.id }, { status: SurveyStates.deleted }],
-			},
-			orderBy: {
-				created_at: 'desc',
-			},
-			select: {
-				id: true,
-			},
-		});
-
-		return previous?.id;
 	}
 
 	public async checkIfAlreadyMigrated(surveyId: string): Promise<boolean> {

--- a/src/schema/survey/survey.repository.spec.ts
+++ b/src/schema/survey/survey.repository.spec.ts
@@ -61,7 +61,7 @@ describe('SurveyRepository', () => {
 				id: '__PREVIOUS_SURVEY_ID__',
 			} as Survey);
 
-			const resultId = await repo.findPreviousSurveyId('__SURVEY_ID__');
+			const resultId = await repo.findIdPreviousSurveyWithNen2767Decomposition('__SURVEY_ID__');
 
 			expect(resultId).toEqual('__PREVIOUS_SURVEY_ID__');
 		});

--- a/src/schema/survey/survey.repository.spec.ts
+++ b/src/schema/survey/survey.repository.spec.ts
@@ -6,10 +6,13 @@ import { SurveyRepository } from './survey.repository';
 import { domainSurvey, survey1, surveyInput } from './__stubs__';
 import { InspectionStandard } from './types';
 import { SurveyStates } from './types/surveyStates';
+import { Survey } from './models/survey.model';
 
 const prismaServiceMock: MockedObjectDeep<PrismaService> = {
 	surveys: {
 		create: jest.fn().mockResolvedValue(domainSurvey),
+		findFirst: jest.fn().mockResolvedValue(domainSurvey),
+		findUnique: jest.fn().mockResolvedValue(domainSurvey),
 	},
 	...(<any>{}),
 };
@@ -48,6 +51,19 @@ describe('SurveyRepository', () => {
 			id: '0deb07f3-28f5-47e1-b72a-d1b2a19d4670',
 			inspectionStandardType: InspectionStandard.spanInstallation,
 			status: SurveyStates.open,
+		});
+	});
+
+	describe('findPrevousSurveyId()', () => {
+		test('returns the id of the survey with the same objectId created prior to the given surveyId, based on the created_at field', async () => {
+			prismaServiceMock.surveys.findFirst.mockResolvedValue({
+				...domainSurvey,
+				id: '__PREVIOUS_SURVEY_ID__',
+			} as Survey);
+
+			const resultId = await repo.findPreviousSurveyId('__SURVEY_ID__');
+
+			expect(resultId).toEqual('__PREVIOUS_SURVEY_ID__');
 		});
 	});
 });

--- a/src/schema/survey/survey.repository.ts
+++ b/src/schema/survey/survey.repository.ts
@@ -6,6 +6,7 @@ import { newId } from '../../utils';
 
 import { DbSurvey, ISurveyRepository } from './types/survey.repository.interface';
 import { CreateSurveyInput } from './dto/create-survey.input';
+import { SurveyStates } from './types/surveyStates';
 
 @Injectable()
 export class SurveyRepository implements ISurveyRepository {
@@ -40,5 +41,35 @@ export class SurveyRepository implements ISurveyRepository {
 		return this.prisma.surveys.findMany({
 			where: { objectId: objectId },
 		});
+	}
+
+	public async findPreviousSurveyId(surveyId: string): Promise<string | null> {
+		const current = await this.prisma.surveys.findFirst({
+			where: {
+				id: surveyId,
+			},
+
+			select: {
+				id: true,
+				objectId: true,
+				inspectionStandardType: true,
+			},
+		});
+
+		const previous = await this.prisma.surveys.findFirst({
+			where: {
+				objectId: current.objectId,
+				inspectionStandardType: current.inspectionStandardType,
+				NOT: [{ id: current.id }, { status: SurveyStates.deleted }],
+			},
+			orderBy: {
+				created_at: 'desc',
+			},
+			select: {
+				id: true,
+			},
+		});
+
+		return previous?.id;
 	}
 }

--- a/src/schema/survey/survey.repository.ts
+++ b/src/schema/survey/survey.repository.ts
@@ -43,7 +43,7 @@ export class SurveyRepository implements ISurveyRepository {
 		});
 	}
 
-	public async findPreviousSurveyId(surveyId: string): Promise<string | null> {
+	public async findIdPreviousSurveyWithNen2767Decomposition(surveyId: string): Promise<string | null> {
 		const current = await this.prisma.surveys.findFirst({
 			where: {
 				id: surveyId,
@@ -59,7 +59,9 @@ export class SurveyRepository implements ISurveyRepository {
 		const previous = await this.prisma.surveys.findFirst({
 			where: {
 				objectId: current.objectId,
-				inspectionStandardType: current.inspectionStandardType,
+				inspectionStandardType: {
+					in: ['nen2767', 'fmeca'],
+				},
 				NOT: [{ id: current.id }, { status: SurveyStates.deleted }],
 			},
 			orderBy: {


### PR DESCRIPTION
Move the `findPreviousSurveyId` method from the Decomposition to Survey repository as it contextually seems to be better coupled with the latter. 