### PR TITLE
fix(nen2767:migrate-decomposition): restoring relations after cloning…

### DIFF
--- a/src/command/cli/nen2767-migrate-decomposition.cli.ts
+++ b/src/command/cli/nen2767-migrate-decomposition.cli.ts
@@ -122,7 +122,7 @@ export class Nen2767MigrateDecompositionCli {
 		);
 		this.progressBar.start(objectsToMigrate.length, 0);
 
-		const queue = new PQueue({ concurrency: 10 });
+		const queue = new PQueue({ concurrency: 5 });
 		objectsToMigrate.forEach(({ id, code }) => {
 			queue.add(() => this.migrateDecompositionForObject(id, code));
 		});


### PR DESCRIPTION
… elements/units/manifestations

For the sake of not extensively repeating myself for each of the 16 related entities I've opted for a generic method which can not be typed using the generated Prisma types. The result is an `any` with a `@ts-ignore` :man_shrugging: 