### PR TITLE
Bugfix/baip 1788

### DIFF
--- a/src/schema/ark-survey/ark-survey.repository.ts
+++ b/src/schema/ark-survey/ark-survey.repository.ts
@@ -42,14 +42,14 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "arkSurveys"
 				SET "arkGeographyStart" = ST_GeomFromGeoJSON(${JSON.stringify(arkGeographyStart)})
-				WHERE "surveyId" = ${arkSurveyRecord.id}
+				WHERE "surveyId" = ${arkSurveyRecord.id}::uuid
 			`;
 		}
 		if (arkGeographyEnd) {
 			await this.prisma.$executeRaw`
 				UPDATE "arkSurveys"
 				SET "arkGeographyEnd" = ST_GeomFromGeoJSON(${JSON.stringify(arkGeographyEnd)})
-				WHERE "surveyId" = ${arkSurveyRecord.id}
+				WHERE "surveyId" = ${arkSurveyRecord.id}::uuid
 			`;
 		}
 
@@ -109,7 +109,7 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "arkSurveys"
 				SET "arkGeographyStart" = ST_GeomFromGeoJSON(${JSON.stringify(arkGeographyStart)})
-				WHERE "surveyId" = ${surveyId}
+				WHERE "surveyId" = ${surveyId}::uuid
 			`;
 		}
 
@@ -117,7 +117,7 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "arkSurveys"
 				SET "arkGeographyEnd" = ST_GeomFromGeoJSON(${JSON.stringify(arkGeographyEnd)})
-				WHERE "surveyId" = ${surveyId}
+				WHERE "surveyId" = ${surveyId}::uuid
 			`;
 		}
 
@@ -268,7 +268,7 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 		const result = await this.prisma.$queryRaw<{ geography?: Point | null }>`
 			SELECT ST_AsGeoJSON("arkGeographyStart") as geography
 			FROM "arkSurveys"
-			WHERE "surveyId" = ${identifier};
+			WHERE "surveyId" = ${identifier}::uuid;
 		`;
 
 		const geography = result?.[0]?.geography;
@@ -279,7 +279,7 @@ export class ArkSurveyRepository implements IArkSurveyRepository {
 		const result = await this.prisma.$queryRaw<{ geography?: Point | null }>`
 			SELECT ST_AsGeoJSON("arkGeographyEnd") as geography
 			FROM "arkSurveys"
-			WHERE "surveyId" = ${identifier};
+			WHERE "surveyId" = ${identifier}::uuid;
 		`;
 
 		const geography = result?.[0]?.geography;

--- a/src/schema/ark-survey/reach-segment.repository.ts
+++ b/src/schema/ark-survey/reach-segment.repository.ts
@@ -48,7 +48,7 @@ export class ReachSegmentRepository implements IReachSegmentRepository {
 	async getHighestSortNumber(arkSurveyId: string): Promise<number> {
 		const result = await this.prisma.$queryRaw<{
 			max: number | null;
-		}>`SELECT MAX("sortNumber") FROM "arkSurveyReachSegments" WHERE "arkSurveyId" = ${arkSurveyId};`;
+		}>`SELECT MAX("sortNumber") FROM "arkSurveyReachSegments" WHERE "arkSurveyId" = ${arkSurveyId}::uuid;`;
 		return result[0].max ?? 0;
 	}
 

--- a/src/schema/asset/asset.repository.ts
+++ b/src/schema/asset/asset.repository.ts
@@ -42,7 +42,7 @@ export class AssetRepository implements IAssetRepository {
 						SELECT "batchExecutorCompanies".id FROM "batchExecutorCompanies"
 						WHERE
 							batches.id = "batchExecutorCompanies"."batchId"
-							AND "batchExecutorCompanies"."companyId" = ${companyId}
+							AND "batchExecutorCompanies"."companyId" = ${companyId}::uuid
 					)
 				)
 		`;

--- a/src/schema/span-installation/junction-box.repository.ts
+++ b/src/schema/span-installation/junction-box.repository.ts
@@ -57,7 +57,7 @@ export class JunctionBoxRepository implements IJunctionBoxRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanJunctionBoxes"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${junctionBox.id}
+				WHERE id = ${junctionBox.id}::uuid
 			`;
 		}
 
@@ -110,7 +110,7 @@ export class JunctionBoxRepository implements IJunctionBoxRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanJunctionBoxes"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${junctionBox.id}
+				WHERE id = ${junctionBox.id}::uuid
 			`;
 		}
 
@@ -170,7 +170,7 @@ export class JunctionBoxRepository implements IJunctionBoxRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanJunctionBoxes"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -222,7 +222,7 @@ export class JunctionBoxRepository implements IJunctionBoxRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanJunctionBoxes"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -291,7 +291,7 @@ export class JunctionBoxRepository implements IJunctionBoxRepository {
 					await this.prisma.$executeRaw`
 						UPDATE "spanJunctionBoxes"
 						SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-						WHERE id = ${newJunctionBoxId}
+						WHERE id = ${newJunctionBoxId}::uuid
 					`;
 				}
 			});

--- a/src/schema/span-installation/luminaire.repository.ts
+++ b/src/schema/span-installation/luminaire.repository.ts
@@ -59,7 +59,7 @@ export class LuminaireRepository implements ILuminaireRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanLuminaires"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${luminaire.id}
+				WHERE id = ${luminaire.id}::uuid
 			`;
 		}
 		return {
@@ -114,7 +114,7 @@ export class LuminaireRepository implements ILuminaireRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanLuminaires"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${luminaire.id}
+				WHERE id = ${luminaire.id}::uuid
 			`;
 		}
 		return {
@@ -177,7 +177,7 @@ export class LuminaireRepository implements ILuminaireRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanLuminaires"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -230,7 +230,7 @@ export class LuminaireRepository implements ILuminaireRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanLuminaires"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -259,7 +259,7 @@ export class LuminaireRepository implements ILuminaireRepository {
 
 	async getGeographyAsGeoJSON(identifier: string): Promise<Point | null> {
 		const result = await this.prisma.$queryRaw<{ geography?: Point | null }>`
-			SELECT ST_AsGeoJSON(geography)::jsonb as geography
+			SELECT ST_AsGeoJSON(geography) as geography
 			FROM "spanLuminaires"
 			WHERE id = ${identifier}::uuid;
 		`;

--- a/src/schema/span-installation/support-system.repository.ts
+++ b/src/schema/span-installation/support-system.repository.ts
@@ -62,7 +62,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 		await this.prisma.$executeRaw`
 			UPDATE "spanSupportSystems"
 			SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-			WHERE id = ${supportSystem.id}
+			WHERE id = ${supportSystem.id}::uuid
 		`;
 
 		return {
@@ -118,7 +118,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 		await this.prisma.$executeRaw`
 			UPDATE "spanSupportSystems"
 			SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-			WHERE id = ${supportSystem.id}
+			WHERE id = ${supportSystem.id}::uuid
 		`;
 
 		return {
@@ -183,7 +183,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanSupportSystems"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -238,7 +238,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 			await this.prisma.$executeRaw`
 				UPDATE "spanSupportSystems"
 				SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-				WHERE id = ${id}
+				WHERE id = ${id}::uuid
 			`;
 		}
 
@@ -313,7 +313,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 					await this.prisma.$executeRaw`
 						UPDATE "spanLuminaires"
 						SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-						WHERE id = ${newLuminaireId}
+						WHERE id = ${newLuminaireId}::uuid
 					`;
 				}
 			});
@@ -349,7 +349,7 @@ export class SupportSystemRepository implements ISupportSystemRepository {
 					await this.prisma.$executeRaw`
 						UPDATE "spanSupportSystems"
 						SET geography = ST_GeomFromGeoJSON(${JSON.stringify(geography)})
-						WHERE id = ${newSupportSystemtId}
+						WHERE id = ${newSupportSystemtId}::uuid
 					`;
 				}
 			});


### PR DESCRIPTION
The Prisma v3 => v4 -> v5 upgrade resulted in injected string values to not be inferred as UUID's